### PR TITLE
Enforce Node.js 22 requirement in setup verification

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,5 +1,13 @@
 # Active Context
 
+- Timestamp: 2025-10-31T20:45:07Z
+- Current focus: Enforce the documented Node.js 22+ baseline in setup verification
+- Implementation status:
+  - ✅ Updated `web/scripts/verify-setup.sh` so Node.js majors below 22 fail and newer majors emit a cautionary warning
+  - ✅ Confirmed the script passes the Node.js check when running `pnpm verify` with Node v22.21.1
+- Immediate next action: Monitor future automation tasks that rely on the setup script now that the runtime requirement is enforced
+- Project Status: ✅ Setup verification aligned with tech context requirements
+
 - Timestamp: 2025-10-21T01:40:00Z
 - Current focus: ✅ PROJECT SETUP COMPLETE - All requirements from problem statement implemented and verified
 - Implementation status:

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,5 +1,11 @@
 # Progress Log
 
+## 2025-10-31
+- **Setup verification aligned with Node.js 22+ baseline**
+  - ✅ Updated `web/scripts/verify-setup.sh` to fail when Node.js < 22 and warn on newer, unvalidated majors
+  - ✅ Ran `pnpm verify` with Node v22.21.1 to confirm the script accepts supported runtimes and communicates other environment gaps
+  - ℹ️ Remaining warnings stem from local environment defaults (Docker not installed, `.env.local` missing, `.key/` directory absent)
+
 ## 2025-10-21
 - **Project Setup Requirements Complete**: Addressed all missing elements required for development
   - ✅ Created `src/features/` directory for feature-specific code organization

--- a/web/scripts/verify-setup.sh
+++ b/web/scripts/verify-setup.sh
@@ -50,13 +50,14 @@ print_info() {
 check_node() {
     print_check "Checking Node.js version..."
     if command -v node &> /dev/null; then
-        NODE_VERSION=$(node --version | cut -d'v' -f2 | cut -d'.' -f1)
-        if [ "$NODE_VERSION" -ge 22 ]; then
-            print_pass "Node.js $(node --version) installed (required: v22+)"
-        elif [ "$NODE_VERSION" -ge 18 ]; then
-            print_warn "Node.js $(node --version) found. v22+ is recommended, but v18+ will work"
+        NODE_VERSION_RAW=$(node --version)
+        NODE_MAJOR=$(echo "$NODE_VERSION_RAW" | cut -d'v' -f2 | cut -d'.' -f1)
+        if [ "$NODE_MAJOR" -lt 22 ]; then
+            print_fail "Node.js $NODE_VERSION_RAW found, but v22+ is required"
+        elif [ "$NODE_MAJOR" -gt 22 ]; then
+            print_warn "Node.js $NODE_VERSION_RAW detected. Baseline requirement is v22+. This major hasn't been validated yet"
         else
-            print_fail "Node.js $(node --version) found, but v18+ is required"
+            print_pass "Node.js $NODE_VERSION_RAW satisfies the v22+ requirement"
         fi
     else
         print_fail "Node.js is not installed"

--- a/web/scripts/verify-setup.sh
+++ b/web/scripts/verify-setup.sh
@@ -55,7 +55,7 @@ check_node() {
         if [ "$NODE_MAJOR" -lt 22 ]; then
             print_fail "Node.js $NODE_VERSION_RAW found, but v22+ is required"
         elif [ "$NODE_MAJOR" -gt 22 ]; then
-            print_warn "Node.js $NODE_VERSION_RAW detected. Baseline requirement is v22+. This major hasn't been validated yet"
+            print_warn "Node.js $NODE_VERSION_RAW detected. Baseline requirement is v22+. This major version hasn't been validated yet"
         else
             print_pass "Node.js $NODE_VERSION_RAW satisfies the v22+ requirement"
         fi


### PR DESCRIPTION
## Summary
- update the setup verification script to require Node.js v22+, warning only when newer majors are detected
- document the runtime enforcement work in the active context and progress memory bank files

## Testing
- PATH=/tmp/node22/node-v22.21.1-linux-x64/bin:$PATH pnpm verify *(fails: Docker not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_69051ef23b488331ab8444c821e41cb4