### PR TITLE
Add cross-platform browser launcher for dev server

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,5 +1,15 @@
 # Active Context
 
+- Timestamp: 2025-10-31T00:00:00Z
+- Current focus: ♻️ Developer experience polish — ensure dev server ergonomics remain cross-platform
+- Implementation status:
+  - ✅ Replaced hard-coded `/usr/bin/google-chrome` launch with `web/scripts/open-browser.mjs`
+  - ✅ Updated `web/package.json` `dev` script to invoke the helper after `wait-on`
+  - ✅ Documented browser auto-launch behavior and opt-out instructions in `web/README.md`
+- Immediate next action: Monitor feedback from contributors using different OS environments and iterate if additional launchers are required.
+- Notes:
+  - Helper selects `open` (macOS), `start` (Windows via `cmd`), or `xdg-open` (Linux/BSD) and falls back to manual launch with warnings when unavailable.
+
 - Timestamp: 2025-10-21T01:40:00Z
 - Current focus: ✅ PROJECT SETUP COMPLETE - All requirements from problem statement implemented and verified
 - Implementation status:

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,5 +1,8 @@
 # Progress Log
 
+## 2025-10-31
+- **Dev server browser helper**: Replaced the Linux-specific Chrome invocation with `web/scripts/open-browser.mjs`, updated the `dev` npm script to call it after `wait-on`, and documented the cross-platform behavior plus opt-out instructions in `web/README.md`.
+
 ## 2025-10-21
 - **Project Setup Requirements Complete**: Addressed all missing elements required for development
   - ✅ Created `src/features/` directory for feature-specific code organization

--- a/web/README.md
+++ b/web/README.md
@@ -106,7 +106,7 @@ Visit [http://localhost:3022](http://localhost:3022)
 
 ### Browser auto-launch helper
 
-When `pnpm dev` runs, the workspace calls `node scripts/open-browser.mjs` after the server is ready. The helper detects your
+When `pnpm dev` runs, the workspace calls `node ./scripts/open-browser.mjs` after the server is ready. The helper detects your
 platform and attempts to open the site using the OS launcher (`open` on macOS, `start` on Windows, `xdg-open` on Linux/BSD). If
 no launcher is available or the command fails, it logs a warning so you can open [http://localhost:3022](http://localhost:3022)
 manually. Use `pnpm dev:no-browser` whenever you prefer to keep the server running without attempting to launch a browser.

--- a/web/README.md
+++ b/web/README.md
@@ -96,13 +96,20 @@ pnpm db:seed
 6. **Start development server**:
 ```bash
 pnpm dev
-# Opens browser automatically at http://localhost:3022
+# Starts the dev server and launches your default browser when possible
 
-# Or without browser:
+# Or without browser auto-launch:
 pnpm dev:no-browser
 ```
 
 Visit [http://localhost:3022](http://localhost:3022)
+
+### Browser auto-launch helper
+
+When `pnpm dev` runs, the workspace calls `node scripts/open-browser.mjs` after the server is ready. The helper detects your
+platform and attempts to open the site using the OS launcher (`open` on macOS, `start` on Windows, `xdg-open` on Linux/BSD). If
+no launcher is available or the command fails, it logs a warning so you can open [http://localhost:3022](http://localhost:3022)
+manually. Use `pnpm dev:no-browser` whenever you prefer to keep the server running without attempting to launch a browser.
 
 For detailed setup instructions, see [SETUP.md](./SETUP.md).
 

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "concurrently \"next dev -p 3022\" \"wait-on http://localhost:3022 && /usr/bin/google-chrome http://localhost:3022\"",
+    "dev": "concurrently \"next dev -p 3022\" \"wait-on http://localhost:3022 && node ./scripts/open-browser.mjs http://localhost:3022\"",
     "dev:no-browser": "next dev -p 3022",
     "build": "next build",
     "start": "next start -p 3022",

--- a/web/scripts/open-browser.mjs
+++ b/web/scripts/open-browser.mjs
@@ -41,14 +41,20 @@ try {
   const child = spawn(command, args, options);
   logInfo(`Attempting to open ${url} using ${command}.`);
 
+  let warned = false;
+
   child.on('error', (error) => {
-    logWarn(`Unable to launch browser using ${command}: ${error.message}`);
-    logWarn(`Please open ${url} manually.`);
+    if (!warned) {
+      warned = true;
+      logWarn(`Unable to launch browser using ${command}: ${error.message}`);
+      logWarn(`Please open ${url} manually.`);
+    }
   });
 
   // Some commands (like xdg-open) exit immediately; treat non-zero exit as warning.
   child.on('exit', (code) => {
-    if (typeof code === 'number' && code !== 0) {
+    if (!warned && typeof code === 'number' && code !== 0) {
+      warned = true;
       logWarn(`Browser launcher ${command} exited with code ${code}. Please open ${url} manually.`);
     }
   });

--- a/web/scripts/open-browser.mjs
+++ b/web/scripts/open-browser.mjs
@@ -39,6 +39,7 @@ if (!command) {
 
 try {
   const child = spawn(command, args, options);
+  logInfo(`Attempting to open ${url} using ${command}.`);
 
   child.on('error', (error) => {
     logWarn(`Unable to launch browser using ${command}: ${error.message}`);
@@ -56,8 +57,6 @@ try {
   if (typeof child.unref === 'function') {
     child.unref();
   }
-
-  logInfo(`Attempting to open ${url} using ${command}.`);
 } catch (error) {
   logWarn(`Failed to spawn ${command}: ${error.message}`);
   logWarn(`Please open ${url} manually.`);

--- a/web/scripts/open-browser.mjs
+++ b/web/scripts/open-browser.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+
+const url = process.argv[2] ?? 'http://localhost:3022';
+const platform = process.platform;
+
+const prefix = '[dev:auto-open]';
+
+const logInfo = (message) => {
+  console.log(`${prefix} ${message}`);
+};
+
+const logWarn = (message) => {
+  console.warn(`${prefix} ${message}`);
+};
+
+let command;
+let args;
+let options = { stdio: 'ignore', detached: true };
+
+if (platform === 'darwin') {
+  command = 'open';
+  args = [url];
+} else if (platform === 'win32') {
+  command = 'cmd';
+  args = ['/c', 'start', '', url];
+  options = { stdio: 'ignore', detached: true, windowsVerbatimArguments: true };
+} else if (platform === 'linux' || platform === 'freebsd' || platform === 'openbsd') {
+  command = 'xdg-open';
+  args = [url];
+} else {
+  command = undefined;
+}
+
+if (!command) {
+  logWarn(`Unsupported platform "${platform}". Please open ${url} manually.`);
+  process.exit(0);
+}
+
+try {
+  const child = spawn(command, args, options);
+
+  child.on('error', (error) => {
+    logWarn(`Unable to launch browser using ${command}: ${error.message}`);
+    logWarn(`Please open ${url} manually.`);
+  });
+
+  // Some commands (like xdg-open) exit immediately; treat non-zero exit as warning.
+  child.on('exit', (code) => {
+    if (typeof code === 'number' && code !== 0) {
+      logWarn(`Browser launcher ${command} exited with code ${code}. Please open ${url} manually.`);
+    }
+  });
+
+  // Allow parent process to continue independently of detached child.
+  if (typeof child.unref === 'function') {
+    child.unref();
+  }
+
+  logInfo(`Attempting to open ${url} using ${command}.`);
+} catch (error) {
+  logWarn(`Failed to spawn ${command}: ${error.message}`);
+  logWarn(`Please open ${url} manually.`);
+}


### PR DESCRIPTION
## Summary
- add a node-based helper that opens the dev server URL with platform-specific launchers
- update the dev npm script to call the helper and document the behavior in the README
- record the change in the memory bank for future contributors

## Testing
- node web/scripts/open-browser.mjs http://localhost:3022

------
https://chatgpt.com/codex/tasks/task_e_69051ed9cf6c8331b54fa51b97854160