### PR TITLE
Normalize UsersRoute role prompt and add tests

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,5 +1,20 @@
 # Active Context
 
+- Timestamp: 2025-11-01T00:00:00Z
+- Current focus: 🔐 Strengthen user management UX safeguards and regression coverage
+- Implementation status:
+  - ✅ Normalized `UsersRoute` add-user prompt to validate roles against the canonical role list
+  - ✅ Added defensive fallback to the viewer role when prompts receive invalid input, with user feedback
+  - ✅ Exported `UsersRoute` for targeted tests without affecting runtime behavior
+  - ✅ Introduced `page.test.tsx` to confirm mixed-case role inputs register correctly across admin/editor/viewer paths
+- Immediate next action: Continue improving dashboard reliability with focused tests around interactive handlers
+- Project Status: 🚧 Feature hardening in progress
+- Notes:
+  - Testing performed with `pnpm vitest run src/app/page.test.tsx`
+  - Validation ensures downstream filters relying on strict `Role` comparisons stay functional
+- Open questions:
+  - Should invalid role prompts abort user creation instead of defaulting to viewer for stricter data hygiene?
+
 - Timestamp: 2025-10-21T01:40:00Z
 - Current focus: ✅ PROJECT SETUP COMPLETE - All requirements from problem statement implemented and verified
 - Implementation status:

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,5 +1,13 @@
 # Progress Log
 
+## 2025-11-01
+- **UsersRoute Role Validation**: Hardened the add-user prompt and added regression coverage
+  - ✅ Normalized prompt input to lowercase and validated against the canonical role list, defaulting to viewer on invalid input
+  - ✅ Updated state mutations to rely on the validated `Role` instance for downstream filters
+  - ✅ Added `web/src/app/page.test.tsx` to verify mixed-case role inputs correctly register as admin/editor/viewer
+  - ✅ Exported `UsersRoute` for targeted testing without impacting runtime consumers
+  - ✅ Test command: `pnpm vitest run src/app/page.test.tsx`
+
 ## 2025-10-21
 - **Project Setup Requirements Complete**: Addressed all missing elements required for development
   - ✅ Created `src/features/` directory for feature-specific code organization

--- a/web/src/app/page.test.tsx
+++ b/web/src/app/page.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * UsersRoute Add User Tests
+ * Ensures role inputs are normalized and validated before saving
+ */
+
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { UsersRoute } from "./page";
+
+const roleTestCases: Array<{
+  expectedRole: "admin" | "editor" | "viewer";
+  input: string;
+}> = [
+  { expectedRole: "admin", input: "AdMiN" },
+  { expectedRole: "editor", input: "EdItOr" },
+  { expectedRole: "viewer", input: "ViEwEr" },
+];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("UsersRoute handleAddUser", () => {
+  it.each(roleTestCases)(
+    "registers $expectedRole when provided as mixed-case $input",
+    ({ expectedRole, input }) => {
+      const promptSpy = vi
+        .spyOn(window, "prompt")
+        .mockReturnValueOnce("Test User")
+        .mockReturnValueOnce(`${expectedRole}@example.com`)
+        .mockReturnValueOnce(input);
+
+      const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+
+      render(<UsersRoute />);
+
+      fireEvent.click(screen.getByRole("button", { name: /add user/i }));
+
+      expect(promptSpy).toHaveBeenCalledTimes(3);
+      expect(alertSpy).not.toHaveBeenCalled();
+
+      const emailCell = screen.getByText(`${expectedRole}@example.com`);
+      const row = emailCell.closest("div");
+      expect(row).not.toBeNull();
+      if (!row) {
+        throw new Error("Row not found for new user");
+      }
+
+      expect(within(row).getByText(expectedRole)).toBeInTheDocument();
+    },
+  );
+});

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -690,7 +690,7 @@ function UsersRoute() {
       normalizedRole &&
       allowedRoles.some((r) => r === normalizedRole);
 
-    if (!isValidRole && roleInput && roleInput.trim() !== "") {
+    if (!isValidRole && roleInput !== null) {
       window.alert(
         `Invalid role "${roleInput}". Defaulting to viewer.`,
       );

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -52,6 +52,8 @@ import { cn, formatDate } from "@/lib/utils";
 /** User role types for access control */
 type Role = "admin" | "editor" | "viewer";
 
+const allowedRoles: Role[] = ["admin", "editor", "viewer"];
+
 /** Available application routes */
 type Route = "dashboard" | "projects" | "users" | "profile" | "settings";
 
@@ -678,10 +680,30 @@ function UsersRoute() {
   const handleAddUser = () => {
     const name = window.prompt("Name?");
     const email = window.prompt("Email?");
-    const roleInput = (window.prompt("Role? (admin|editor|viewer)", "viewer") ??
-      "viewer") as Role;
+    const roleInput = window.prompt(
+      "Role? (admin|editor|viewer)",
+      "viewer",
+    );
     if (!name || !email) return;
-    setRows((previous) => [...previous, { name, email, role: roleInput }]);
+    const normalizedRole = roleInput?.trim().toLowerCase();
+    const isValidRole =
+      normalizedRole &&
+      allowedRoles.includes(normalizedRole as Role);
+
+    if (!isValidRole && roleInput && roleInput.trim() !== "") {
+      window.alert(
+        `Invalid role "${roleInput}". Defaulting to viewer.`,
+      );
+    }
+
+    const validatedRole: Role = isValidRole
+      ? (normalizedRole as Role)
+      : "viewer";
+
+    setRows((previous) => [
+      ...previous,
+      { name, email, role: validatedRole },
+    ]);
   };
 
   return (
@@ -1024,6 +1046,8 @@ function SignInScreen({
     </div>
   );
 }
+
+export { UsersRoute, allowedRoles };
 
 /**
  * Dashboard Shell - Main Application Component

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -688,7 +688,7 @@ function UsersRoute() {
     const normalizedRole = roleInput?.trim().toLowerCase();
     const isValidRole =
       normalizedRole &&
-      allowedRoles.includes(normalizedRole as Role);
+      allowedRoles.some((r) => r === normalizedRole);
 
     if (!isValidRole && roleInput && roleInput.trim() !== "") {
       window.alert(


### PR DESCRIPTION
## Summary
- normalize the add-user prompt in `UsersRoute` and validate against the allowed roles list with a fallback message
- export `UsersRoute` and add a vitest harness that verifies mixed-case admin/editor/viewer inputs register correctly
- document the change in the memory bank for ongoing context tracking

## Testing
- pnpm vitest run src/app/page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_69051f1018b4833188eb941d27c3c6a1