### PR TITLE
Add Prisma-backed utilities API for dashboard data

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -79,6 +79,10 @@
   - TypeScript configuration now uses "react-jsx" for automatic JSX runtime
   - next-auth shows peer dependency warning but remains fully functional
   - All existing features (screenshot automation, authentication, database) working correctly
+- Backend integration kick-off:
+  - Created Prisma-backed utilities query module with aggregate helpers for favorites and usage counts
+  - Added `/api/utilities` route handler returning enriched catalogue data with Next.js 16 dynamic caching headers
+  - Covered data mapping logic with Vitest unit tests mocking Prisma client
 - Open questions:
   - Should we monitor next-auth updates for official Next.js 16 support?
   - Are there Next.js 16 specific features we should leverage (explicit caching, etc.)?

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -93,6 +93,12 @@ Resolved firewall blocking issues for Chromium/Playwright and Prisma services:
   - All existing functionality verified to ensure no regressions
 - **Next Steps**: Monitor next-auth for Next.js 16 support, explore Next.js 16 explicit caching features, continue with dashboard development
 
+### Utilities API bootstrap
+- ✅ Implemented `src/features/utilities/queries.ts` to read Prisma catalogue data and compute favorite/usage aggregates
+- ✅ Added `GET /api/utilities` route exposing enriched utility data with explicit dynamic caching headers
+- ✅ Created Vitest coverage for data mapping via Prisma client mocks
+- 🔄 Next step: connect dashboard client state to the new API and wire cache tag invalidation when mutating utilities
+
 ## 2025-10-29
 - **Screenshot Automation System Implemented**: Comprehensive screenshot capture capabilities for agentic workflows
   - ✅ Created TypeScript screenshot utility in `web/src/utils/screenshot.ts` with full TSDoc documentation

--- a/web/src/app/api/utilities/route.ts
+++ b/web/src/app/api/utilities/route.ts
@@ -1,0 +1,47 @@
+/**
+ * Utilities collection endpoint.
+ * Provides a Prisma-backed catalogue response for dashboard hydration.
+ */
+
+import { NextResponse } from "next/server";
+
+import { listUtilities } from "@/features/utilities";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/utilities
+ *
+ * Returns the complete list of utilities with aggregate insights so the
+ * dashboard can hydrate table and card views without duplicating logic.
+ */
+export async function GET() {
+  try {
+    const utilities = await listUtilities();
+
+    return NextResponse.json(
+      { utilities },
+      {
+        status: 200,
+        headers: {
+          "Cache-Control": "private, max-age=0, must-revalidate",
+        },
+      },
+    );
+  } catch (error) {
+    console.error("Failed to load utilities", error);
+
+    return NextResponse.json(
+      {
+        error: "Unable to load utilities",
+      },
+      {
+        status: 500,
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  }
+}

--- a/web/src/features/utilities/index.ts
+++ b/web/src/features/utilities/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Utilities feature entry point.
+ * Re-exports data access helpers for consumers.
+ */
+
+export type { UtilitySummary } from "./queries";
+export { listUtilities } from "./queries";

--- a/web/src/features/utilities/queries.test.ts
+++ b/web/src/features/utilities/queries.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { UtilitySummary } from "./queries";
+import { listUtilities } from "./queries";
+
+const findManyMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    utility: {
+      findMany: findManyMock,
+    },
+  },
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("listUtilities", () => {
+  it("returns utilities enriched with aggregate metadata", async () => {
+    const metadata = {
+      features: ["format", "validate", 42],
+      keywords: ["json", "tools"],
+      unsupported: "ignored",
+    };
+
+    findManyMock.mockResolvedValueOnce([
+      {
+        id: "util_1",
+        name: "json-formatter",
+        title: "JSON Formatter",
+        description: "Format JSON payloads",
+        category: "text",
+        icon: "code",
+        path: "/utilities/json-formatter",
+        isActive: true,
+        metadata,
+        updatedAt: new Date("2025-10-20T15:00:00.000Z"),
+        userUtilities: [
+          { isFavorite: true, usageCount: 5 },
+          { isFavorite: false, usageCount: 2 },
+        ],
+      },
+      {
+        id: "util_2",
+        name: "hash-generator",
+        title: "Hash Generator",
+        description: null,
+        category: "security",
+        icon: null,
+        path: "/utilities/hash-generator",
+        isActive: false,
+        metadata: null,
+        updatedAt: new Date("2025-10-19T11:30:00.000Z"),
+        userUtilities: [
+          { isFavorite: false, usageCount: 0 },
+        ],
+      },
+    ]);
+
+    const result = await listUtilities();
+
+    expect(findManyMock).toHaveBeenCalledWith({
+      include: {
+        userUtilities: {
+          select: {
+            isFavorite: true,
+            usageCount: true,
+          },
+        },
+      },
+      orderBy: {
+        title: "asc",
+      },
+    });
+
+    const expected: UtilitySummary[] = [
+      {
+        id: "util_1",
+        name: "json-formatter",
+        title: "JSON Formatter",
+        description: "Format JSON payloads",
+        category: "text",
+        icon: "code",
+        path: "/utilities/json-formatter",
+        isActive: true,
+        updatedAt: "2025-10-20T15:00:00.000Z",
+        favoriteCount: 1,
+        totalUsage: 7,
+        features: ["format", "validate"],
+        keywords: ["json", "tools"],
+        metadata,
+      },
+      {
+        id: "util_2",
+        name: "hash-generator",
+        title: "Hash Generator",
+        description: null,
+        category: "security",
+        icon: null,
+        path: "/utilities/hash-generator",
+        isActive: false,
+        updatedAt: "2025-10-19T11:30:00.000Z",
+        favoriteCount: 0,
+        totalUsage: 0,
+        features: [],
+        keywords: [],
+        metadata: null,
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/web/src/features/utilities/queries.ts
+++ b/web/src/features/utilities/queries.ts
@@ -1,0 +1,89 @@
+/**
+ * Utility feature queries.
+ * Provides Prisma-backed data fetchers for the utilities catalogue.
+ */
+
+import { prisma } from "@/lib/db/prisma";
+
+/** Structured representation of a utility record returned to API consumers. */
+export type UtilitySummary = {
+  id: string;
+  name: string;
+  title: string;
+  description: string | null;
+  category: string;
+  icon: string | null;
+  path: string;
+  isActive: boolean;
+  updatedAt: string;
+  favoriteCount: number;
+  totalUsage: number;
+  features: string[];
+  keywords: string[];
+  metadata: Record<string, unknown> | null;
+};
+
+/**
+ * Normalize an arbitrary metadata field into a list of strings.
+ */
+function normalizeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+/**
+ * Fetch the full utilities catalogue with aggregate insights.
+ *
+ * @returns A sorted list of utilities enriched with favorite and usage counts.
+ */
+export async function listUtilities(): Promise<UtilitySummary[]> {
+  const utilities = await prisma.utility.findMany({
+    include: {
+      userUtilities: {
+        select: {
+          isFavorite: true,
+          usageCount: true,
+        },
+      },
+    },
+    orderBy: {
+      title: "asc",
+    },
+  });
+
+  return utilities.map((utility) => {
+    const metadata = (utility.metadata ?? null) as Record<string, unknown> | null;
+    const features = metadata ? normalizeStringArray(metadata.features) : [];
+    const keywords = metadata ? normalizeStringArray(metadata.keywords) : [];
+
+    const favoriteCount = utility.userUtilities.reduce(
+      (count, association) => count + (association.isFavorite ? 1 : 0),
+      0,
+    );
+
+    const totalUsage = utility.userUtilities.reduce(
+      (sum, association) => sum + (association.usageCount ?? 0),
+      0,
+    );
+
+    return {
+      id: utility.id,
+      name: utility.name,
+      title: utility.title,
+      description: utility.description,
+      category: utility.category,
+      icon: utility.icon,
+      path: utility.path,
+      isActive: utility.isActive,
+      updatedAt: utility.updatedAt.toISOString(),
+      favoriteCount,
+      totalUsage,
+      features,
+      keywords,
+      metadata,
+    } satisfies UtilitySummary;
+  });
+}


### PR DESCRIPTION
## Summary
- add a Prisma-powered utilities query helper that aggregates favorites and usage counts
- expose a GET /api/utilities route that returns enriched catalogue data with explicit dynamic caching headers
- cover the new data mapping with Vitest tests and document the work in the memory bank

## Testing
- pnpm test --run *(fails: existing `sleep` timing assertion flake)*

------
https://chatgpt.com/codex/tasks/task_e_69051eb3d8c48331ba4e2fb5b276b97f